### PR TITLE
chore: update repo references from ZertoPublic to recklessop

### DIFF
--- a/zroc-ova/README.md
+++ b/zroc-ova/README.md
@@ -7,7 +7,7 @@ Packer build definitions and provisioner scripts for the **zROC Ubuntu 26.04 LTS
 A 100 GB thin-provisioned VMware OVA containing:
 - Ubuntu Server 26.04 LTS
 - Docker Engine + Compose plugin
-- Full zROC stack (cloned from ZertoPublic/zroc)
+- Full zROC stack (cloned from recklessop/zroc)
 - Interactive first-boot setup wizard (`zroc-setup`)
 - UFW firewall pre-configured (22, 80, 443, 3000)
 - VMware guest tools (`open-vm-tools`)
@@ -16,7 +16,7 @@ A 100 GB thin-provisioned VMware OVA containing:
 ## Build
 
 ```bash
-git clone https://github.com/ZertoPublic/zroc-ova.git
+git clone https://github.com/recklessop/zroc-ova.git
 cd zroc-ova
 make init
 make validate

--- a/zroc-ova/scripts/02-zroc.sh
+++ b/zroc-ova/scripts/02-zroc.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 echo "==> [02-zroc] Setting up zROC installation"
 
 INSTALL_DIR=/opt/zroc
-ZROC_REPO="https://github.com/ZertoPublic/zroc.git"
+ZROC_REPO="https://github.com/recklessop/zroc.git"
 
 git clone --depth=1 "$ZROC_REPO" "$INSTALL_DIR"
 

--- a/zroc-ova/scripts/04-systemd-service.sh
+++ b/zroc-ova/scripts/04-systemd-service.sh
@@ -6,7 +6,7 @@ echo "==> [04-systemd-service] Installing zroc.service"
 cat > /etc/systemd/system/zroc.service << 'EOF'
 [Unit]
 Description=zROC Observability Stack
-Documentation=https://github.com/ZertoPublic/zroc
+Documentation=https://github.com/recklessop/zroc
 After=docker.service network-online.target
 Requires=docker.service
 Wants=network-online.target

--- a/zroc-ui/DOCKER_README.md
+++ b/zroc-ui/DOCKER_README.md
@@ -23,7 +23,7 @@ This image includes a Node.js Express backend that handles:
 ## Quick start — full stack
 
 ```bash
-git clone https://github.com/ZertoPublic/zroc.git
+git clone https://github.com/recklessop/zroc.git
 cd zroc
 cp .env.example .env
 # Edit .env with your ZVM credentials and secrets
@@ -56,9 +56,9 @@ Then visit `https://<your-host>` — on first access run through the setup wizar
 
 ## Source
 
-- UI & backend: [github.com/ZertoPublic/zroc](https://github.com/ZertoPublic/zroc)
+- UI & backend: [github.com/recklessop/zroc](https://github.com/recklessop/zroc)
 - Zerto Exporter: [github.com/recklessop/Zerto_Exporter](https://github.com/recklessop/Zerto_Exporter)
-- OVA Appliance: [github.com/ZertoPublic/zroc-ova](https://github.com/ZertoPublic/zroc-ova)
+- OVA Appliance: [github.com/recklessop/zroc-ova](https://github.com/recklessop/zroc-ova)
 
 ## License
 

--- a/zroc-ui/README.md
+++ b/zroc-ui/README.md
@@ -18,7 +18,7 @@ zROC is a Docker Compose stack that collects Zerto metrics via the ZVM REST API 
 ## Quick Start
 
 ```bash
-git clone https://github.com/ZertoPublic/zroc.git
+git clone https://github.com/recklessop/zroc.git
 cd zroc
 cp .env.example .env
 # Edit .env with your ZVM credentials and secrets


### PR DESCRIPTION
## Summary

- Updated all `ZertoPublic/zroc` references to `recklessop/zroc` across 5 files
- Files updated: `zroc-ova/README.md`, `zroc-ova/scripts/02-zroc.sh`, `zroc-ova/scripts/04-systemd-service.sh`, `zroc-ui/README.md`, `zroc-ui/DOCKER_README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)